### PR TITLE
Add unit tests with coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "node --test --experimental-test-coverage"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/src/data/transactions.js
+++ b/src/data/transactions.js
@@ -1,0 +1,20 @@
+const transactions = [
+  { id: 1, date: '2024-01-05', description: 'Salary', category: 'Income', type: 'income', amount: 5000 },
+  { id: 2, date: '2024-01-10', description: 'Groceries', category: 'Food', type: 'expense', amount: 120 },
+  { id: 3, date: '2024-01-15', description: 'Electricity Bill', category: 'Utilities', type: 'expense', amount: 60 },
+  { id: 4, date: '2024-02-03', description: 'Freelance Project', category: 'Income', type: 'income', amount: 800 },
+  { id: 5, date: '2024-02-14', description: 'Restaurant', category: 'Food', type: 'expense', amount: 45 },
+  { id: 6, date: '2024-03-07', description: 'Rent', category: 'Housing', type: 'expense', amount: 1000 },
+  { id: 7, date: '2024-03-18', description: 'Stock Dividend', category: 'Investment', type: 'income', amount: 200 },
+  { id: 8, date: '2023-11-22', description: 'Car Repair', category: 'Transport', type: 'expense', amount: 300 },
+  { id: 9, date: '2023-12-02', description: 'Bonus', category: 'Income', type: 'income', amount: 1200 },
+  { id: 10, date: '2024-04-13', description: 'New Laptop', category: 'Electronics', type: 'expense', amount: 1500 },
+  { id: 11, date: '2024-04-20', description: 'Tax Refund', category: 'Income', type: 'income', amount: 400 },
+  { id: 12, date: '2024-05-05', description: 'Vacation', category: 'Travel', type: 'expense', amount: 700 },
+  { id: 13, date: '2024-06-09', description: 'Gift', category: 'Income', type: 'income', amount: 150 },
+  { id: 14, date: '2024-06-15', description: 'Internet Bill', category: 'Utilities', type: 'expense', amount: 80 },
+  { id: 15, date: '2024-07-01', description: 'Salary', category: 'Income', type: 'income', amount: 5200 },
+  { id: 16, date: '2024-07-09', description: 'Gym Membership', category: 'Health', type: 'expense', amount: 50 },
+];
+
+export default transactions;

--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -1,0 +1,30 @@
+
+export function filterTransactions(data, filter) {
+  return data.filter((t) => {
+    const matchQuery = t.description.toLowerCase().includes(filter.query.toLowerCase());
+    const matchType = filter.type === 'all' || t.type === filter.type;
+    const afterFrom = !filter.from || new Date(t.date) >= new Date(filter.from);
+    const beforeTo = !filter.to || new Date(t.date) <= new Date(filter.to);
+    return matchQuery && matchType && afterFrom && beforeTo;
+  });
+}
+
+export function aggregateByMonth(data) {
+  const map = {};
+  data.forEach((t) => {
+    const key = new Date(t.date).toISOString().slice(0, 7);
+    if (!map[key]) map[key] = { income: 0, expense: 0 };
+    map[key][t.type] += t.amount;
+  });
+  return map;
+}
+
+export function aggregateByYear(data) {
+  const map = {};
+  data.forEach((t) => {
+    const key = new Date(t.date).getFullYear().toString();
+    if (!map[key]) map[key] = { income: 0, expense: 0 };
+    map[key][t.type] += t.amount;
+  });
+  return map;
+}

--- a/test/transactionService.test.js
+++ b/test/transactionService.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import transactions from '../src/data/transactions.js';
+import { filterTransactions, aggregateByMonth, aggregateByYear } from '../src/services/transactionService.js';
+
+// Sample filter for testing
+const baseFilter = { query: '', from: '', to: '', type: 'all' };
+
+test('filterTransactions filters by type', () => {
+  const income = filterTransactions(transactions, { ...baseFilter, type: 'income' });
+  assert.ok(income.every(t => t.type === 'income'));
+
+  const expense = filterTransactions(transactions, { ...baseFilter, type: 'expense' });
+  assert.ok(expense.every(t => t.type === 'expense'));
+});
+
+test('filterTransactions filters by query and dates', () => {
+  const res = filterTransactions(transactions, { ...baseFilter, query: 'salary', from: '2024-07-01', to: '2024-07-31' });
+  assert.strictEqual(res.length, 1);
+  assert.strictEqual(res[0].description, 'Salary');
+});
+
+test('aggregateByMonth summarizes income and expenses per month', () => {
+  const aggr = aggregateByMonth(transactions);
+  assert.ok(aggr['2024-01']);
+  assert.strictEqual(aggr['2024-01'].income, 5000);
+  assert.strictEqual(aggr['2024-01'].expense, 180);
+});
+
+test('aggregateByYear summarizes income and expenses per year', () => {
+  const aggr = aggregateByYear(transactions);
+  assert.ok(aggr['2024']);
+  assert.ok(aggr['2023']);
+  assert.strictEqual(aggr['2023'].expense, 300);
+  assert.strictEqual(aggr['2024'].income >= 5000, true);
+});


### PR DESCRIPTION
## Summary
- enable `npm test` using Node's built-in test runner with coverage
- add JS versions of data and service modules for the test runner
- create unit tests for transaction service functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876386c63e483309b5376e33e9d264d