### PR TITLE
Improve dashboard performance with caching and pagination

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import transactions from '@/data/transactions'
+
+export const revalidate = 60
+
+export async function GET() {
+  return NextResponse.json(transactions, {
+    headers: {
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=120'
+    }
+  })
+}

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -3,11 +3,24 @@ import { Transaction } from '@/data/transactions';
 
 interface Props {
   transactions: Transaction[];
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
 }
 
-export default function TransactionsTable({ transactions }: Props) {
+export default function TransactionsTable({
+  transactions,
+  page,
+  pageSize,
+  onPageChange,
+}: Props) {
+  const pageCount = Math.ceil(transactions.length / pageSize) || 1;
+  const start = (page - 1) * pageSize;
+  const visible = transactions.slice(start, start + pageSize);
+
   return (
-    <table className="w-full text-sm border-collapse">
+    <div>
+      <table className="w-full text-sm border-collapse">
       <thead>
         <tr>
           <th className="border p-2 text-left">Fecha</th>
@@ -17,7 +30,7 @@ export default function TransactionsTable({ transactions }: Props) {
         </tr>
       </thead>
       <tbody>
-        {transactions.map((t) => (
+        {visible.map((t) => (
           <tr key={t.id} className="odd:bg-gray-100">
             <td className="border p-2">{t.date}</td>
             <td className="border p-2">{t.description}</td>
@@ -28,6 +41,26 @@ export default function TransactionsTable({ transactions }: Props) {
           </tr>
         ))}
       </tbody>
-    </table>
+      </table>
+      <div className="flex items-center justify-between mt-2 text-sm">
+        <button
+          className="px-2 py-1 border rounded disabled:opacity-50"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+        >
+          Anterior
+        </button>
+        <span>
+          Página {page} de {pageCount}
+        </span>
+        <button
+          className="px-2 py-1 border rounded disabled:opacity-50"
+          onClick={() => onPageChange(page + 1)}
+          disabled={page >= pageCount}
+        >
+          Siguiente
+        </button>
+      </div>
+    </div>
   );
 }

--- a/src/services/transactionService.js
+++ b/src/services/transactionService.js
@@ -1,12 +1,21 @@
 
+const filterCache = new Map();
+
 export function filterTransactions(data, filter) {
-  return data.filter((t) => {
+  const key = JSON.stringify(filter);
+  const cached = filterCache.get(key);
+  if (cached) return cached;
+
+  const result = data.filter((t) => {
     const matchQuery = t.description.toLowerCase().includes(filter.query.toLowerCase());
     const matchType = filter.type === 'all' || t.type === filter.type;
     const afterFrom = !filter.from || new Date(t.date) >= new Date(filter.from);
     const beforeTo = !filter.to || new Date(t.date) <= new Date(filter.to);
     return matchQuery && matchType && afterFrom && beforeTo;
   });
+
+  filterCache.set(key, result);
+  return result;
 }
 
 export function aggregateByMonth(data) {

--- a/src/services/transactionService.ts
+++ b/src/services/transactionService.ts
@@ -7,8 +7,14 @@ export interface Filter {
   type: 'all' | 'income' | 'expense';
 }
 
+const filterCache = new Map<string, Transaction[]>();
+
 export function filterTransactions(data: Transaction[], filter: Filter) {
-  return data.filter((t) => {
+  const key = JSON.stringify(filter);
+  const cached = filterCache.get(key);
+  if (cached) return cached;
+
+  const result = data.filter((t) => {
     const matchQuery = t.description
       .toLowerCase()
       .includes(filter.query.toLowerCase());
@@ -17,6 +23,9 @@ export function filterTransactions(data: Transaction[], filter: Filter) {
     const beforeTo = !filter.to || new Date(t.date) <= new Date(filter.to);
     return matchQuery && matchType && afterFrom && beforeTo;
   });
+
+  filterCache.set(key, result);
+  return result;
 }
 
 export function aggregateByMonth(data: Transaction[]) {


### PR DESCRIPTION
## Summary
- create API route for transactions with cache headers
- memoize `filterTransactions` results
- add pagination controls to the transactions table
- fetch transactions and lazy-load dashboard charts

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68763b271a4883308c4f2281ab5da7d6