### PR TITLE
Implement basic token-based auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 # Copy to .env and set values accordingly
 DATABASE_URL=postgresql://user:password@localhost:5432/finnance
 NEXT_PUBLIC_API_URL=http://localhost:3000/api
+# Authentication tokens for API access
+# Replace with strong, random values in production
+ADMIN_TOKEN=changeme-admin
+USER_TOKEN=changeme-user

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,12 +1,51 @@
-import { NextResponse } from 'next/server'
-import transactions from '@/data/transactions'
+import { NextRequest, NextResponse } from 'next/server'
+import transactions, { type Transaction } from '@/data/transactions'
+import { requireAuth } from '@/lib/auth'
+import { sanitizeString } from '@/lib/sanitize'
 
 export const revalidate = 60
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const auth = requireAuth(request, ['admin', 'user'])
+  if (auth) return auth
+
   return NextResponse.json(transactions, {
     headers: {
       'Cache-Control': 'public, max-age=60, stale-while-revalidate=120'
     }
   })
+}
+
+export async function POST(request: NextRequest) {
+  const auth = requireAuth(request, ['admin'])
+  if (auth) return auth
+
+  const body = await request.json().catch(() => null)
+  if (!body)
+    return new NextResponse('Invalid JSON', { status: 400 })
+
+  const { date, description, category, type, amount } = body as Record<string, unknown>
+
+  if (
+    typeof date !== 'string' ||
+    typeof description !== 'string' ||
+    typeof category !== 'string' ||
+    (type !== 'income' && type !== 'expense') ||
+    typeof amount !== 'number'
+  ) {
+    return new NextResponse('Bad Request', { status: 400 })
+  }
+
+  const newTx: Transaction = {
+    id: transactions.length + 1,
+    date: sanitizeString(date),
+    description: sanitizeString(description),
+    category: sanitizeString(category),
+    type,
+    amount,
+  }
+
+  transactions.push(newTx)
+
+  return NextResponse.json(newTx, { status: 201 })
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function requireAuth(
+  request: NextRequest,
+  allowedRoles: string[]
+): NextResponse | null {
+  const header = request.headers.get('authorization') || ''
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null
+
+  const admin = process.env.ADMIN_TOKEN
+  const user = process.env.USER_TOKEN
+
+  let role: string | null = null
+  if (token && token === admin) role = 'admin'
+  else if (token && token === user) role = 'user'
+
+  if (!role) return new NextResponse('Unauthorized', { status: 401 })
+  if (!allowedRoles.includes(role))
+    return new NextResponse('Forbidden', { status: 403 })
+
+  return null
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,3 @@
+export function sanitizeString(value: string): string {
+  return value.replace(/[<>]/g, '')
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from './lib/auth'
+
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname.startsWith('/api/')) {
+    const res = requireAuth(request, ['admin', 'user'])
+    if (res) return res
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+}


### PR DESCRIPTION
## Summary
- add example ADMIN_TOKEN and USER_TOKEN placeholders
- implement token authorization middleware
- secure `/api/transactions` with role checks
- sanitize new transaction data and allow POST

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68763e8c8c6883309c40d7cfee207d9c