### PR TITLE
Add onboarding documentation and API spec

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Código de Conducta
+
+Este proyecto adopta la [Contributor Covenant](https://www.contributor-covenant.org/es/version/2/1/code_of_conduct/) en su versión 2.1.
+
+## Nuestro Compromiso
+
+Nos comprometemos a crear un entorno abierto y acogedor, donde cualquier persona pueda participar con respeto y sin discriminación.
+
+## Nuestras Normas
+
+- Utiliza un lenguaje amable y profesional.
+- Respeta los diferentes puntos de vista y experiencias.
+- Acepta de manera constructiva las críticas y sugerencias.
+- Abstente de conductas y comentarios ofensivos o de acoso.
+
+## Alcance
+
+Este código de conducta se aplica dentro de todos los espacios del proyecto, incluyendo issues, pull requests y cualquier comunicación oficial.
+
+## Contacto
+
+Si observas un comportamiento inaceptable, por favor contacta a los mantenedores a través de `contact@example.com`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Guía de Contribución
+
+¡Gracias por interesarte en colaborar con Finnance! Sigue estos pasos para contribuir de manera efectiva.
+
+## Requisitos Previos
+
+- Node.js >= 20
+- npm
+
+## Flujo de Trabajo
+
+1. **Fork y clona el repositorio**
+   ```bash
+   git clone https://github.com/tu-usuario/finnance.git
+   cd finnance
+   ```
+2. **Crea tu rama de trabajo desde `dev`**
+   ```bash
+   git checkout dev
+   git pull origin dev
+   git checkout -b feature/mi-cambio
+   ```
+3. **Instala dependencias y ejecuta pruebas**
+   ```bash
+   npm install
+   npm test
+   ```
+4. **Realiza tus cambios** siguiendo las convenciones de [BRANCHING.md](BRANCHING.md).
+5. **Commit y push**
+   ```bash
+   git add .
+   git commit -m "feat: describe tu cambio"
+   git push origin feature/mi-cambio
+   ```
+6. **Abre un Pull Request** hacia la rama `dev`.
+
+## Estilo de Código
+
+- Usa `npm run lint` para verificar el estilo.
+- Escribe pruebas cuando sea posible.
+- Sigue las convenciones de [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Código de Conducta
+
+Al participar, aceptas cumplir el [Código de Conducta](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI/CD Pipeline](https://github.com/atomic0supply/finnance/actions/workflows/ci.yml/badge.svg)](https://github.com/atomic0supply/finnance/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Personal Finance App built with shadcn/ui to help you manage and track all your personal expenses, bills, properties, vehicles, and payment schedules in one place.
+Aplicación de finanzas personales construida con Next.js y shadcn/ui para gestionar gastos, propiedades, vehículos y calendarios de pago en un solo lugar.
 
 ## 🌳 Estructura del Proyecto
 
@@ -38,40 +38,63 @@ Data Storage: LocalStorage (for MVP) / SQLite or Postgres (for future expansion)
 
 Calendar: FullCalendar or React Calendar integration
 
-💾 Installation
+## 🏗️ Arquitectura
 
-Clone the repo
+La aplicación está construida con **Next.js** utilizando el directorio `src`:
 
+- `app/` contiene las rutas de la interfaz y las API (`api/transactions`).
+- `components/` agrupa componentes reutilizables de React.
+- `services/` incluye la lógica de negocio, como el servicio de transacciones.
+- `data/` almacena datos de ejemplo usados durante el desarrollo.
+
+La documentación de la API se encuentra en [`docs/openapi.yaml`](docs/openapi.yaml) y puede explorarse con cualquier visor de Swagger.
+
+## 🔧 Puesta en marcha
+
+```bash
 git clone https://github.com/your-username/finnance.git
 cd finnance
-
-Install dependencies
-
 npm install
-# or
-yarn install
-
-Copy environment variables template
-
 cp .env.example .env
-
-Set up shadcn/ui
-
 npx shadcn-ui init
-
-Run the development server
-
 npm run dev
-# or
-yarn dev
+```
 
-Run type checks
+Variables de entorno relevantes:
+- `ADMIN_TOKEN` y `USER_TOKEN` para autenticar las peticiones a la API.
 
-npm run typecheck
-# or
-yarn typecheck
+Ejecuta `npm run typecheck` para validar TypeScript. La aplicación estará disponible en `http://localhost:3000`.
 
-Your app should now be running at http://localhost:3000.
+## 📑 Comandos útiles
+
+| Comando            | Descripción                     |
+|--------------------|---------------------------------|
+| `npm run dev`      | Inicia el servidor de desarrollo|
+| `npm test`         | Ejecuta la suite de pruebas     |
+| `npm run lint`     | Revisa el formato del código    |
+| `npm run build`    | Genera la versión de producción |
+| `npm start`        | Sirve la aplicación compilada   |
+
+## 🧪 Tests
+
+Las pruebas están escritas con el runner de Node. Ejecuta:
+
+```bash
+npm test
+```
+
+Se generará un reporte de cobertura en la terminal.
+
+## 🚀 Despliegue
+
+Para generar una build de producción ejecuta:
+
+```bash
+npm run build
+npm start
+```
+
+Estos comandos compilan la aplicación y la sirven en modo producción.
 
 ⚙️ Usage
 
@@ -85,15 +108,7 @@ View Calendar: Open the Calendar view to see payment due dates and filter by cat
 
 🤝 Contributing
 
-Fork the repository
-
-Create a feature branch (git checkout -b feature/YourFeature)
-
-Commit your changes (git commit -m "feat: Add new feature")
-
-Push to the branch (git push origin feature/YourFeature)
-
-Open a Pull Request
+Consulta la guía de contribución en [CONTRIBUTING.md](CONTRIBUTING.md) para conocer el flujo de trabajo y las normas del proyecto.
 
 📄 License
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.0
+info:
+  title: Finnance API
+  version: 1.0.0
+  description: |-
+    API para gestionar transacciones financieras.
+    Autenticación mediante tokens Bearer definidos en las variables de entorno `ADMIN_TOKEN` y `USER_TOKEN`.
+servers:
+  - url: http://localhost:3000
+paths:
+  /api/transactions:
+    get:
+      summary: Obtener todas las transacciones
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Lista de transacciones
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Transaction'
+    post:
+      summary: Crear una transacción
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewTransaction'
+      responses:
+        '201':
+          description: Transacción creada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '400':
+          description: Solicitud inválida
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    Transaction:
+      type: object
+      properties:
+        id:
+          type: integer
+        date:
+          type: string
+          format: date
+        description:
+          type: string
+        category:
+          type: string
+        type:
+          type: string
+          enum: [income, expense]
+        amount:
+          type: number
+      required:
+        - id
+        - date
+        - description
+        - category
+        - type
+        - amount
+    NewTransaction:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        description:
+          type: string
+        category:
+          type: string
+        type:
+          type: string
+          enum: [income, expense]
+        amount:
+          type: number
+      required:
+        - date
+        - description
+        - category
+        - type
+        - amount


### PR DESCRIPTION
## Summary
- expand README with architecture overview, start/testing/deploy commands and API link
- add contribution guidelines and code of conduct
- document transactions API via OpenAPI spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876426ef6b8833084ea716b14d670ef